### PR TITLE
mainloop: add hooks for driving epoll externally.

### DIFF
--- a/attrib/gatt.c
+++ b/attrib/gatt.c
@@ -31,6 +31,7 @@
 
 #include <glib.h>
 
+#include "lib/bluetooth.h"
 #include "lib/sdp.h"
 #include "lib/sdp_lib.h"
 #include "lib/uuid.h"

--- a/profiles/audio/avrcp.c
+++ b/profiles/audio/avrcp.c
@@ -42,9 +42,9 @@
 #include <glib.h>
 #include <dbus/dbus.h>
 
-#include "bluetooth/bluetooth.h"
-#include "bluetooth/sdp.h"
-#include "bluetooth/sdp_lib.h"
+#include "lib/bluetooth.h"
+#include "lib/sdp.h"
+#include "lib/sdp_lib.h"
 #include "lib/uuid.h"
 
 #include "gdbus/gdbus.h"

--- a/src/shared/mainloop.h
+++ b/src/shared/mainloop.h
@@ -36,6 +36,9 @@ void mainloop_quit(void);
 void mainloop_exit_success(void);
 void mainloop_exit_failure(void);
 int mainloop_run(void);
+int mainloop_run_init(void);
+int mainloop_run_exit(void);
+void mainloop_tick(int timeout);
 
 int mainloop_add_fd(int fd, uint32_t events, mainloop_event_func callback,
 				void *user_data, mainloop_destroy_func destroy);


### PR DESCRIPTION
This allows easier integration of bluez into other systems.  An external polling loop can drive bluez by calling `mainloop_tick()`, and still manage its own sockets and file descriptors, while allowing bluez to manage its internal bluetooth related sockets using its standard means.